### PR TITLE
Fix admin imports to match lowercase `components/` folder (Linux CI)

### DIFF
--- a/admin/src/pages/Admin/AddDoctor.jsx
+++ b/admin/src/pages/Admin/AddDoctor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAddDoctor } from '../../hooks/useAddDoctor';
-import DoctorImageUpload from '../../Components/doctor-form/DoctorImageUpload.jsx';
-import { PersonalSection, ProfessionalSection, AboutSection } from '../../Components/doctor-form/DoctorFormSections.jsx';
+import DoctorImageUpload from '../../components/doctor-form/DoctorImageUpload.jsx';
+import { PersonalSection, ProfessionalSection, AboutSection } from '../../components/doctor-form/DoctorFormSections.jsx';
 
 const AddDoctor = () => {
   const { form, setField, docImg, setDocImg, loading, onSubmit, resetForm, goToList } = useAddDoctor();

--- a/admin/src/pages/Admin/Dashboard.jsx
+++ b/admin/src/pages/Admin/Dashboard.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useAdminDashboard } from '../../hooks/useAdminDashboard';
-import StatsCards from '../../Components/admin/dashboard/StatsCards.jsx';
-import MigrationBanner from '../../Components/admin/dashboard/MigrationBanner.jsx';
-import ActivityLogsBanner from '../../Components/admin/dashboard/ActivityLogsBanner.jsx';
-import RecentAppointments from '../../Components/admin/dashboard/RecentAppointments.jsx';
+import StatsCards from '../../components/admin/dashboard/StatsCards.jsx';
+import MigrationBanner from '../../components/admin/dashboard/MigrationBanner.jsx';
+import ActivityLogsBanner from '../../components/admin/dashboard/ActivityLogsBanner.jsx';
+import RecentAppointments from '../../components/admin/dashboard/RecentAppointments.jsx';
 
 const Dashboard = () => {
   const { dashData, isApproving, approveExistingDoctors } = useAdminDashboard();

--- a/admin/src/pages/AdminForgotPassword.jsx
+++ b/admin/src/pages/AdminForgotPassword.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import ForgotEmailForm from '../Components/auth/ForgotEmailForm.jsx';
-import AdminResetPasswordForm from '../Components/auth/AdminResetPasswordForm.jsx';
+import ForgotEmailForm from '../components/auth/ForgotEmailForm.jsx';
+import AdminResetPasswordForm from '../components/auth/AdminResetPasswordForm.jsx';
 import { useAdminForgotPassword } from '../hooks/useAdminForgotPassword';
 
 const InfoBox = () => (

--- a/admin/src/pages/AdminLogin.jsx
+++ b/admin/src/pages/AdminLogin.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import AuthLayout from '../Components/auth/AuthLayout.jsx';
-import { AuthIcon, ShieldIcon } from '../Components/auth/AuthIcon.jsx';
-import EmailField from '../Components/auth/EmailField.jsx';
-import PasswordField from '../Components/auth/PasswordField.jsx';
-import SubmitButton from '../Components/auth/SubmitButton.jsx';
-import AuthLinks from '../Components/auth/AuthLinks.jsx';
+import AuthLayout from '../components/auth/AuthLayout.jsx';
+import { AuthIcon, ShieldIcon } from '../components/auth/AuthIcon.jsx';
+import EmailField from '../components/auth/EmailField.jsx';
+import PasswordField from '../components/auth/PasswordField.jsx';
+import SubmitButton from '../components/auth/SubmitButton.jsx';
+import AuthLinks from '../components/auth/AuthLinks.jsx';
 import { useAdminLogin } from '../hooks/useAdminLogin';
 
 const Icon = () => <AuthIcon accent="blue"><ShieldIcon /></AuthIcon>;

--- a/admin/src/pages/DoctorLogin.jsx
+++ b/admin/src/pages/DoctorLogin.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import AuthLayout from '../Components/auth/AuthLayout.jsx';
-import { AuthIcon, DoctorIcon } from '../Components/auth/AuthIcon.jsx';
-import EmailField from '../Components/auth/EmailField.jsx';
-import PasswordField from '../Components/auth/PasswordField.jsx';
-import SubmitButton from '../Components/auth/SubmitButton.jsx';
-import AuthLinks from '../Components/auth/AuthLinks.jsx';
+import AuthLayout from '../components/auth/AuthLayout.jsx';
+import { AuthIcon, DoctorIcon } from '../components/auth/AuthIcon.jsx';
+import EmailField from '../components/auth/EmailField.jsx';
+import PasswordField from '../components/auth/PasswordField.jsx';
+import SubmitButton from '../components/auth/SubmitButton.jsx';
+import AuthLinks from '../components/auth/AuthLinks.jsx';
 import { useDoctorLogin } from '../hooks/useDoctorLogin';
 
 const Icon = () => <AuthIcon accent="green"><DoctorIcon /></AuthIcon>;

--- a/admin/src/pages/LandingPage.jsx
+++ b/admin/src/pages/LandingPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import LandingHero from '../Components/landing/LandingHero.jsx';
-import AccessCards from '../Components/landing/AccessCards.jsx';
-import PlatformFeatures from '../Components/landing/PlatformFeatures.jsx';
+import LandingHero from '../components/landing/LandingHero.jsx';
+import AccessCards from '../components/landing/AccessCards.jsx';
+import PlatformFeatures from '../components/landing/PlatformFeatures.jsx';
 
 const LandingPage = () => (
   <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
Vercel/GitHub runners are Linux (case-sensitive FS). Windows/macOS builds passed because they're case-insensitive, but Linux rejects:

  Could not resolve "../Components/landing/LandingHero.jsx" from
  "src/pages/LandingPage.jsx"

The tracked folder is `admin/src/components/` (lowercase). Fixed the uppercase `Components/` imports in:
  pages/LandingPage.jsx
  pages/AdminLogin.jsx
  pages/DoctorLogin.jsx
  pages/AdminForgotPassword.jsx
  pages/Admin/AddDoctor.jsx
  pages/Admin/Dashboard.jsx

No content changes, just path casing.