### PR TITLE
Backend release workflow: source env vars from Doppler instead of GH …

### DIFF
--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -2,6 +2,10 @@ name: Build & Release — backend (AWS Lambda)
 
 # Manual-only. Start a run from the Actions tab when you want a new
 # backend build to hit Lambda.
+#
+# Env vars (MongoDB, JWT, Cloudinary, Stripe, SMTP, etc.) come from
+# Doppler at deploy time via `doppler run`. Only AWS credentials and the
+# Doppler service token live in GitHub secrets.
 on:
   workflow_dispatch:
     inputs:
@@ -31,22 +35,12 @@ jobs:
       run:
         working-directory: backend
     env:
-      # AWS
+      # AWS (used by serverless to deploy; NOT injected by Doppler)
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION || 'ap-south-1' }}
-
-      # Runtime env vars (forwarded into Lambda via serverless.yml)
-      MONGODB_URI: ${{ secrets.MONGODB_URI }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      CLOUDINARY_NAME: ${{ secrets.CLOUDINARY_NAME }}
-      CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-      CLOUDINARY_SECRET_KEY: ${{ secrets.CLOUDINARY_SECRET_KEY }}
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      EMAIL_USER: ${{ secrets.EMAIL_USER }}
-      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
-      FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
-      ADMIN_URL: ${{ secrets.ADMIN_URL }}
+      # Doppler service token scoped to clickandcare-backend / prd
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -62,5 +56,12 @@ jobs:
       - name: Install Serverless Framework
         run: npm i -g serverless@3
 
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Build & Release (stage=${{ inputs.stage }})
-        run: serverless deploy --stage ${{ inputs.stage }} --verbose
+        # `doppler run --preserve-env` keeps AWS_* from the GH env intact while
+        # also injecting MONGODB_URI / JWT_SECRET / CLOUDINARY_* / STRIPE_* /
+        # EMAIL_* / FRONTEND_URL / ADMIN_URL from Doppler. Serverless then reads
+        # them via ${env:VAR} in serverless.yml and bakes them into the Lambda.
+        run: doppler run --preserve-env -- serverless deploy --stage ${{ inputs.stage }} --verbose

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -78,22 +78,30 @@ Settings → Secrets and variables → Actions → **New repository secret**:
 | `VERCEL_PROJECT_ID_FRONTEND` | `projectId` of the frontend Vercel project |
 | `VERCEL_PROJECT_ID_ADMIN` | `projectId` of the admin Vercel project |
 
-### AWS / Serverless
+### AWS (GitHub secrets)
 | Secret | Value |
 |---|---|
 | `AWS_ACCESS_KEY_ID` | from IAM user |
 | `AWS_SECRET_ACCESS_KEY` | from IAM user |
 | `AWS_REGION` | e.g. `ap-south-1` (optional — defaults to ap-south-1) |
-| `MONGODB_URI` | your Mongo Atlas connection string (**no trailing `/dbname`** — the code appends `/Click&Care`) |
-| `JWT_SECRET` | strong random string |
-| `CLOUDINARY_NAME` | Cloudinary cloud name |
-| `CLOUDINARY_API_KEY` | |
-| `CLOUDINARY_SECRET_KEY` | |
-| `STRIPE_SECRET_KEY` | `sk_live_…` or `sk_test_…` |
-| `EMAIL_USER` | SMTP sender |
-| `EMAIL_PASSWORD` | SMTP app password |
-| `FRONTEND_URL` | prod frontend URL (for CORS + Stripe return URLs) |
-| `ADMIN_URL` | prod admin URL (for CORS) |
+
+### Doppler (GitHub secret + Doppler project)
+Runtime env vars live in a Doppler project (`clickandcare-backend`, config `prd`). The workflow pulls them at deploy time, so they never touch GitHub.
+
+**GitHub secret:**
+| Secret | Value |
+|---|---|
+| `DOPPLER_TOKEN` | Doppler → `clickandcare-backend` → **Access → Service Tokens** → create one scoped to the `prd` config (read-only) |
+
+**Doppler `clickandcare-backend` / prd config should contain:**
+
+- `MONGODB_URI` (Mongo Atlas conn string, **no trailing `/dbname`** — code appends `/Click&Care`)
+- `JWT_SECRET` (long random string)
+- `CLOUDINARY_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_SECRET_KEY`
+- `STRIPE_SECRET_KEY` (`sk_live_…` or `sk_test_…`)
+- `EMAIL_USER`, `EMAIL_PASSWORD`
+- `FRONTEND_URL` (prod frontend, for CORS + Stripe return URLs)
+- `ADMIN_URL` (prod admin, for CORS)
 
 ---
 


### PR DESCRIPTION
…secrets

Replaces the long list of GitHub secrets (MONGODB_URI, JWT_SECRET, CLOUDINARY_*, STRIPE_*, EMAIL_*, FRONTEND_URL, ADMIN_URL) with a single DOPPLER_TOKEN. All runtime vars now live in the Doppler project `clickandcare-backend` / config `prd` and are injected at deploy time.

Workflow change:
- Add dopplerhq/cli-action@v3 step to install Doppler CLI.
- Wrap `serverless deploy` in `doppler run --preserve-env --` so the subprocess sees both AWS_* (from GH env) and the Doppler vars, which serverless.yml then reads via ${env:VAR} to bake into the Lambda.

Kept as GH secrets (these are deploy-time auth, not runtime):
- AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
- DOPPLER_TOKEN (service token scoped to clickandcare-backend/prd)

DEPLOY.md updated with the new secret split + Doppler config checklist.