### PR TITLE
SPA fallback in Vercel rewrites — fixes 404 on deep-link refresh

### DIFF
--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -3,6 +3,10 @@
     {
       "source": "/api/:path*",
       "destination": "https://pjzyuwdvf8.execute-api.ap-south-1.amazonaws.com/api/:path*"
+    },
+    {
+      "source": "/((?!assets/).*)",
+      "destination": "/index.html"
     }
   ]
 }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,6 +3,10 @@
     {
       "source": "/api/:path*",
       "destination": "https://pjzyuwdvf8.execute-api.ap-south-1.amazonaws.com/api/:path*"
+    },
+    {
+      "source": "/((?!assets/).*)",
+      "destination": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
Adds a catch-all rewrite to both frontend/vercel.json and admin/vercel.json that serves index.html for any path not matching a static asset. Without this, refreshing on /login (or any client-side route) returned a Vercel 404 because Vercel looked for a static /login file that doesn't exist.

Order matters: /api/* rewrite stays first, then the SPA fallback. The fallback excludes /assets/* (the regex `/((?!assets/).*)`) so JS/CSS bundles still serve as static files, not as index.html.