### PR TITLE
Socket host: EC2 t4g.nano deployment

### DIFF
--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,24 @@
+# Caddy auto-issues + renews Let's Encrypt SSL for the hostname.
+# Copy this file to /etc/caddy/Caddyfile on the EC2 box, replace the
+# domain, then `sudo systemctl reload caddy`.
+
+socket.chikitsalaya.live {
+    # Forward everything to the Node Socket.IO server on localhost:3000.
+    # Caddy speaks HTTP/2 and HTTP/3 to the browser; node still sees plain HTTP.
+    reverse_proxy localhost:3000 {
+        # Required for WebSocket upgrade
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto https
+    }
+
+    # Cap log spam — Caddy logs every request by default.
+    log {
+        output file /var/log/caddy/socket.log {
+            roll_size 50mb
+            roll_keep 3
+        }
+        level INFO
+    }
+}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,6 +46,83 @@ AWS Lambda cannot hold persistent WebSocket connections. The REST API ships to L
 
 Both are ignored in dev (Vite proxy handles everything).
 
+## Socket host: AWS EC2 t4g.nano
+
+We run the same `backend/` code on a tiny EC2 box for Socket.IO. Free for the first 12 months on the AWS Free Tier (750 instance-hours/month covers 24/7), ~$3-4/mo after that.
+
+### One-time EC2 setup
+
+1. **Launch the instance**
+   - AWS Console → EC2 → **Launch instance**
+   - Name: `clickandcare-socket`
+   - AMI: **Amazon Linux 2023** (free-tier eligible)
+   - Instance type: **t4g.nano** (ARM, free tier)
+   - Key pair: create a new one, download the `.pem` (you'll use it for ssh)
+   - Network → Security group rules:
+     - SSH (22) from your IP only
+     - HTTP (80) from anywhere — Caddy uses it for Let's Encrypt cert renewal
+     - HTTPS (443) from anywhere — actual socket traffic
+   - Storage: 8 GB gp3 (default)
+   - Launch
+   - Note the **public IPv4 address**
+
+2. **Point DNS at the box**
+   - Your DNS provider (name.com) → add an `A` record:
+     - Host: `socket`
+     - Answer: `<EC2 public IPv4>`
+     - TTL: 300
+   - Result: `socket.chikitsalaya.live` → your EC2 instance
+
+3. **SSH in and bootstrap**
+   ```bash
+   ssh -i ~/Downloads/your-key.pem ec2-user@<EC2 public IPv4>
+   curl -fsSL https://raw.githubusercontent.com/aries1232/ClickAndCare/main/scripts/setup-ec2.sh | bash
+   ```
+   The bootstrap installs Node 20, pm2, Doppler CLI, Caddy, and clones the repo.
+
+4. **Wire Doppler runtime env**
+   On the EC2 box:
+   ```bash
+   doppler login                 # follow the link, paste the code
+   doppler setup                 # pick clickandcare-be / config prd
+   cd ~/ClickAndCare/backend
+   doppler run -- pm2 start ecosystem.config.cjs
+   pm2 save
+   sudo env PATH=$PATH pm2 startup systemd -u ec2-user --hp /home/ec2-user
+   # pm2 prints a `sudo …` command — paste and run it. This makes pm2
+   # re-launch your server automatically after the box reboots.
+   ```
+
+5. **Set up Caddy for HTTPS**
+   ```bash
+   sudo cp ~/ClickAndCare/Caddyfile.example /etc/caddy/Caddyfile
+   sudo nano /etc/caddy/Caddyfile     # change 'socket.chikitsalaya.live' if needed
+   sudo systemctl enable --now caddy
+   ```
+   Caddy auto-issues a Let's Encrypt cert in ~30s. Test:
+   ```
+   curl https://socket.chikitsalaya.live/api/health
+   ```
+
+6. **Point the frontend + admin at it**
+   In Doppler:
+   - `clickandcare-fe / prd` → `VITE_SOCKET_URL = https://socket.chikitsalaya.live`
+   - `clickandcare-admin / prd` → `VITE_SOCKET_URL = https://socket.chikitsalaya.live`
+   Re-run **Build & Release — frontend** and **Build & Release — admin** in GitHub Actions.
+
+7. **Set a billing alert (so you never get surprised)**
+   AWS Console → Billing → **Budgets** → Create budget → "Zero spend budget" template → email yourself if cost goes over $1.
+
+### Updating after pushing new code
+```bash
+ssh -i your-key.pem ec2-user@<ip>
+cd ~/ClickAndCare && git pull
+cd backend && npm ci --omit=dev
+pm2 restart clickandcare-socket
+```
+
+Or wire it into GitHub Actions later if you want auto-deploy.
+
 ---
 
 ## First-time setup

--- a/backend/ecosystem.config.cjs
+++ b/backend/ecosystem.config.cjs
@@ -1,0 +1,26 @@
+// pm2 config — keeps `node server.js` alive on the EC2 box, restarts on
+// crash, restarts on reboot (with `pm2 startup`), captures logs.
+//
+// Usage on EC2:
+//   cd ~/ClickAndCare/backend
+//   doppler run -- pm2 start ecosystem.config.cjs
+//   pm2 save
+//   sudo pm2 startup            (one-time; pm2 prints the exact command)
+
+module.exports = {
+  apps: [
+    {
+      name: 'clickandcare-socket',
+      script: 'server.js',
+      instances: 1,
+      exec_mode: 'fork',
+      autorestart: true,
+      max_memory_restart: '300M',
+      env: {
+        NODE_ENV: 'production',
+        // PORT is read by server.js. Caddy proxies to localhost:3000.
+        PORT: '3000',
+      },
+    },
+  ],
+};

--- a/scripts/setup-ec2.sh
+++ b/scripts/setup-ec2.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# One-shot bootstrap for a fresh Amazon Linux 2023 (or Ubuntu) EC2 instance
+# that hosts ONLY the always-on Socket.IO server. REST API stays on Lambda.
+#
+# Usage (from your laptop, not the EC2 box):
+#   scp scripts/setup-ec2.sh ec2-user@<your-ip>:~
+#   ssh ec2-user@<your-ip> 'bash ~/setup-ec2.sh'
+#
+# Or run the steps manually from EC2 Web SSH if you don't have ssh keys handy.
+#
+# Idempotent: rerunning is safe.
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/aries1232/ClickAndCare.git}"
+REPO_DIR="${REPO_DIR:-$HOME/ClickAndCare}"
+NODE_MAJOR="${NODE_MAJOR:-20}"
+
+echo "▶ Detecting OS…"
+. /etc/os-release
+echo "  → $PRETTY_NAME"
+
+echo "▶ Installing system packages…"
+if [[ "$ID" == "amzn" ]]; then
+  sudo dnf -y install git curl tar gzip
+elif [[ "$ID" == "ubuntu" || "$ID" == "debian" ]]; then
+  sudo apt update
+  sudo apt -y install git curl ca-certificates
+else
+  echo "Unknown distro: $ID — install git+curl manually and re-run."
+  exit 1
+fi
+
+echo "▶ Installing Node.js $NODE_MAJOR via NodeSource…"
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL "https://rpm.nodesource.com/setup_${NODE_MAJOR}.x" 2>/dev/null \
+    | sudo bash - || true
+  if [[ "$ID" == "amzn" ]]; then
+    sudo dnf -y install nodejs
+  else
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | sudo -E bash -
+    sudo apt -y install nodejs
+  fi
+fi
+echo "  → node $(node -v)"
+
+echo "▶ Installing pm2 (process keeper)…"
+sudo npm i -g pm2
+
+echo "▶ Installing Doppler CLI (for env vars at runtime)…"
+if ! command -v doppler >/dev/null 2>&1; then
+  curl -Ls https://cli.doppler.com/install.sh | sudo sh
+fi
+echo "  → $(doppler --version)"
+
+echo "▶ Installing Caddy (HTTPS reverse proxy with auto-Let's-Encrypt)…"
+if ! command -v caddy >/dev/null 2>&1; then
+  if [[ "$ID" == "amzn" ]]; then
+    sudo dnf -y install 'dnf-command(copr)' || true
+    sudo dnf copr enable -y @caddy/caddy || true
+    sudo dnf -y install caddy
+  else
+    sudo apt -y install debian-keyring debian-archive-keyring apt-transport-https
+    curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+    sudo apt update && sudo apt -y install caddy
+  fi
+fi
+echo "  → $(caddy version)"
+
+echo "▶ Cloning repo…"
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+  git clone "$REPO_URL" "$REPO_DIR"
+else
+  git -C "$REPO_DIR" fetch origin
+  git -C "$REPO_DIR" reset --hard origin/main
+fi
+
+echo "▶ Installing backend dependencies…"
+cd "$REPO_DIR/backend"
+npm ci --omit=dev
+
+echo
+echo "✅ Bootstrap complete."
+echo
+echo "Next steps:"
+echo "  1. doppler login                # authenticate to Doppler on this box"
+echo "  2. doppler setup                # pick project clickandcare-be / config prd"
+echo "  3. cd $REPO_DIR/backend"
+echo "  4. doppler run -- pm2 start ecosystem.config.cjs"
+echo "  5. pm2 save && sudo pm2 startup  # auto-restart pm2 on reboot"
+echo "  6. sudo cp $REPO_DIR/Caddyfile.example /etc/caddy/Caddyfile"
+echo "     # then edit /etc/caddy/Caddyfile to set your real domain"
+echo "  7. sudo systemctl enable --now caddy"
+echo


### PR DESCRIPTION
Adds the bits for hosting the always-on Socket.IO server on a free-tier EC2 instance, separate from the Lambda REST API.

- scripts/setup-ec2.sh: one-shot bootstrap (Node 20 via NodeSource, pm2, Doppler CLI, Caddy, clone repo, npm ci). Idempotent.
- Caddyfile.example: HTTPS reverse proxy template (auto-Let's-Encrypt on the configured domain, WebSocket upgrade headers, log rotation).
- backend/ecosystem.config.cjs: pm2 process config — autorestart on crash, 300 MB memory cap, fixed PORT=3000 (Caddy proxies to it).
- DEPLOY.md: full first-time EC2 walkthrough — instance launch, security group ports (22/80/443), DNS A record, SSH bootstrap, Doppler login, pm2 + systemd autostart, Caddy enable, Doppler VITE_SOCKET_URL update, billing alert. Plus an "updating after push" snippet.

Free for first 12 months on AWS Free Tier; ~$3-4/mo after.