### PR TITLE
admin: relative URLs in prod (was hardcoding localhost:3000)

### DIFF
--- a/admin/src/components/ChatBox.jsx
+++ b/admin/src/components/ChatBox.jsx
@@ -4,7 +4,11 @@ import { useSocketContext } from '../context/SocketContext.jsx';
 import { FaImage } from 'react-icons/fa';
 import axios from 'axios';
 
-const SOCKET_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+// Sockets go to the always-on VITE_SOCKET_URL in prod; REST falls back to a
+// relative URL which Vercel proxies to Lambda. Dev uses the Vite proxy.
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL
+  || import.meta.env.VITE_BACKEND_URL
+  || (import.meta.env.DEV ? 'http://localhost:3000' : '');
 
 function formatDate(dateStr) {
   if (!dateStr) return '';

--- a/admin/src/context/AdminContext.jsx
+++ b/admin/src/context/AdminContext.jsx
@@ -23,7 +23,10 @@ export const AdminContext = createContext();
 const errMsg = (e, fallback) => e.response?.data?.message || e.message || fallback;
 
 const AdminContextProvider = (props) => {
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+  // Dev fallback hits the local backend through Vite's proxy. In prod we leave
+  // backendUrl empty so any `${backendUrl}/api/...` URL stays relative — Vercel's
+  // /api/* rewrite then proxies it to Lambda (same-origin from the browser).
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || (import.meta.env.DEV ? 'http://localhost:3000' : '');
   const [aToken, setAToken] = useState(localStorage.getItem('aToken') || '');
   const [doctors, setDoctors] = useState([]);
   const [appointments, setAppointments] = useState([]);

--- a/admin/src/context/DoctorContext.jsx
+++ b/admin/src/context/DoctorContext.jsx
@@ -20,7 +20,10 @@ export const DoctorContext = createContext();
 const errMsg = (e, fallback) => e.response?.data?.message || e.message || fallback;
 
 const DoctorContextProvider = (props) => {
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+  // Dev fallback hits the local backend through Vite's proxy. In prod we leave
+  // backendUrl empty so any `${backendUrl}/api/...` URL stays relative — Vercel's
+  // /api/* rewrite then proxies it to Lambda (same-origin from the browser).
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || (import.meta.env.DEV ? 'http://localhost:3000' : '');
   const [dToken, setDToken] = useState(localStorage.getItem('dToken') || '');
   const [appointments, setAppointments] = useState([]);
   const [dashData, setDashData] = useState(false);


### PR DESCRIPTION
The unrefactored admin code (DoctorAppointments, ChatBox, etc.) builds absolute URLs from `${backendUrl}/api/...`, where backendUrl came from `import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'`. With VITE_BACKEND_URL unset in Doppler, prod browsers were calling http://localhost:3000 → CORS rejection → chat broken on admin.

Fix: keep the localhost fallback only in dev. In prod, leave backendUrl empty so URLs stay relative — Vercel's `/api/*` rewrite proxies them to Lambda (same-origin from the browser, no CORS preflight).

Touches AdminContext, DoctorContext, ChatBox (which had its own SOCKET_URL constant pointing at the same fallback).