### PR TITLE
Silence chat console.log in production

### DIFF
--- a/frontend/src/context/SocketContext.jsx
+++ b/frontend/src/context/SocketContext.jsx
@@ -41,13 +41,11 @@ export const SocketContextProvider = ({ children }) => {
       
       // Listen for new messages
       newSocket.on("receiveMessage", (message) => {
-        console.log('SocketContext: Received message:', message);
-        // Dispatch custom event for components to handle
         window.dispatchEvent(new CustomEvent('newMessage', {
           detail: {
             appointmentId: message.appointmentId,
-            message: message
-          }
+            message,
+          },
         }));
       });
       


### PR DESCRIPTION
Removes the leftover `SocketContext: Received message:` log that fired on every incoming chat message. It was useful while debugging the socket→DOM event bridge but spams DevTools in production.