### PR TITLE
Switch email transport from Gmail to generic SMTP (Resend default)

### DIFF
--- a/backend/controllers/doctorController.js
+++ b/backend/controllers/doctorController.js
@@ -4,30 +4,23 @@ import jwt from 'jsonwebtoken'
 import appointmentModel from "../models/appointmentModel.js";
 import validator from 'validator';
 import { v2 as cloudinary } from 'cloudinary';
-import nodemailer from 'nodemailer';
 import { logAdminAction } from '../utils/adminLogger.js';
 import Conversation from '../models/Conversation.js';
 import Message from '../models/Message.js';
 import { getPaginatedMessages } from '../utils/chatPagination.js';
+import { sendEmail as sendEmailShared } from '../utils/emailService.js';
 
 // Generate OTP
 const generateOTP = () => {
     return Math.floor(100000 + Math.random() * 900000).toString();
 };
 
-// Send OTP email
+// Send OTP email — delegates to the shared transporter in utils/emailService.js
+// (the previous inline copy used the wrong API name `createTransporter` and
+// the wrong env var `EMAIL_PASS`, so it likely never worked).
 const sendOTPEmail = async (email, otp) => {
     try {
-        const transporter = nodemailer.createTransporter({
-            service: 'gmail',
-            auth: {
-                user: process.env.EMAIL_USER,
-                pass: process.env.EMAIL_PASS
-            }
-        });
-
-        const mailOptions = {
-            from: process.env.EMAIL_USER,
+        return await sendEmailShared({
             to: email,
             subject: 'ClickAndCare - Email Verification OTP',
             html: `
@@ -41,11 +34,8 @@ const sendOTPEmail = async (email, otp) => {
                     <p>This code will expire in 10 minutes.</p>
                     <p>If you didn't request this code, please ignore this email.</p>
                 </div>
-            `
-        };
-
-        await transporter.sendMail(mailOptions);
-        return true;
+            `,
+        });
     } catch (error) {
         console.error('Email sending error:', error);
         return false;

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -3,45 +3,35 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-// Debug: Check if environment variables are loaded
-console.log('Email configuration:');
-console.log('EMAIL_USER:', process.env.EMAIL_USER ? 'Set' : 'NOT SET');
-console.log('EMAIL_PASSWORD:', process.env.EMAIL_PASSWORD ? 'Set' : 'NOT SET');
-
-// Create transporter
+// Generic SMTP transport — works with any provider (Resend, SES, Mailgun, etc.).
+// Defaults are tuned for Resend so you only need EMAIL_USER (e.g. "resend") and
+// EMAIL_PASSWORD (the API key) in env. Override host/port if using a different
+// provider.
 const transporter = nodemailer.createTransport({
-  service: 'gmail',
+  host: process.env.EMAIL_HOST || 'smtp.resend.com',
+  port: Number(process.env.EMAIL_PORT) || 465,
+  secure: process.env.EMAIL_SECURE !== 'false', // true for 465, false for 587
   auth: {
     user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASSWORD
-  }
+    pass: process.env.EMAIL_PASSWORD,
+  },
 });
+
+// EMAIL_FROM is the visible "from" address (e.g. "ClickAndCare <noreply@chikitsalaya.live>").
+// Falls back to EMAIL_USER for back-compat with old Gmail setup.
+const fromAddress = process.env.EMAIL_FROM || process.env.EMAIL_USER;
 
 // Generic email sending function
 export const sendEmail = async ({ to, subject, html }) => {
-  const mailOptions = {
-    from: process.env.EMAIL_USER,
-    to,
-    subject,
-    html
-  };
-
   try {
-    console.log('Sending email with options:', {
-      from: mailOptions.from,
-      to: mailOptions.to,
-      subject: mailOptions.subject
-    });
-    
-    const result = await transporter.sendMail(mailOptions);
-    console.log('Email sent successfully:', result.messageId);
+    await transporter.sendMail({ from: fromAddress, to, subject, html });
     return true;
   } catch (error) {
-    console.error('Error sending email:', error);
-    console.error('Error details:', {
+    console.error('emailService.sendEmail error:', {
       code: error.code,
       command: error.command,
-      response: error.response
+      response: error.response,
+      message: error.message,
     });
     return false;
   }
@@ -49,11 +39,8 @@ export const sendEmail = async ({ to, subject, html }) => {
 
 // Send OTP verification email
 export const sendOTPEmail = async (email, otp, name) => {
-  console.log('Attempting to send OTP email to:', email);
-  console.log('OTP:', otp);
-  
   const mailOptions = {
-    from: process.env.EMAIL_USER,
+    from: fromAddress,
     to: email,
     subject: 'Email Verification OTP - ClickAndCare',
     html: `
@@ -113,7 +100,7 @@ export const sendOTPEmail = async (email, otp, name) => {
 // Send appointment confirmation email
 export const sendAppointmentConfirmation = async (email, appointmentData, userName) => {
   const mailOptions = {
-    from: process.env.EMAIL_USER,
+    from: fromAddress,
     to: email,
     subject: 'Appointment Confirmation - ClickAndCare',
     html: `
@@ -174,7 +161,7 @@ export const sendPasswordResetOTP = async (email, otp, name) => {
   console.log('OTP:', otp);
   
   const mailOptions = {
-    from: process.env.EMAIL_USER,
+    from: fromAddress,
     to: email,
     subject: 'Password Reset OTP - ClickAndCare',
     html: `


### PR DESCRIPTION
Generalize the nodemailer transport to read EMAIL_HOST/EMAIL_PORT/ EMAIL_SECURE from env with Resend-friendly defaults, and add an EMAIL_FROM for the visible sender address. Drop the inline Gmail-only OTP sender in doctorController (which had a `createTransporter` typo and used the wrong env var name) in favor of the shared sendEmail helper.