### PR TITLE
Make booking redirect to Stripe in one gesture

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -372,16 +372,18 @@ const bookAppointment = async (req, res) => {
 const allAppointments = async (req, res) => {
   try {
     const userId = req.user.id;
-    // Hide rows whose soft-lock has expired without payment — they're
-    // effectively abandoned. The row stays in the DB for audit.
-    const now = new Date();
+    // Booking is now a single redirect-to-Stripe gesture — there's no
+    // legitimate "unpaid pending" state for a user to look at. Show only
+    // paid / cancelled / completed rows. Soft-locked-but-unpaid rows are
+    // an in-flight checkout (user is on the Stripe page or abandoned the
+    // tab); they don't belong in the user-facing list.
     const data = await appointmentModel
       .find({
         userId,
         $or: [
           { payment: true },
           { cancelled: true },
-          { lockExpiresAt: { $gt: now } },
+          { isCompleted: true },
         ],
       })
       .sort({ date: -1 });

--- a/frontend/src/Components/appointments/AppointmentActions.jsx
+++ b/frontend/src/Components/appointments/AppointmentActions.jsx
@@ -15,30 +15,10 @@ const UnreadBadge = ({ count }) => {
   );
 };
 
-const AppointmentActions = ({ appointment, unreadCount, onPay, onCancel, onOpenChat }) => {
-  if (!appointment.payment && !appointment.cancelled && !appointment.isCompleted) {
-    return (
-      <>
-        <button
-          onClick={() => onPay(appointment._id)}
-          className="text-sm text-stone-400 text-center sm:min-w-48 py-2 border rounded hover:bg-primary hover:text-white transition-all duration-300"
-        >
-          Pay Now
-        </button>
-        <button
-          className="text-sm text-stone-400 text-center sm:min-w-48 py-2 border rounded hover:bg-red-600 hover:text-white transition-all duration-300"
-          onClick={() => onCancel(appointment._id)}
-        >
-          Cancel Appointment
-        </button>
-      </>
-    );
-  }
-
+const AppointmentActions = ({ appointment, unreadCount, onCancel, onOpenChat }) => {
   if (appointment.payment && !appointment.isCompleted && !appointment.cancelled) {
     return (
       <>
-        <button className="sm:min-w-48 py-2 border border-green-500 rounded text-green-500">Payment Done !</button>
         <button
           className="relative inline-flex items-center justify-center px-4 py-2 bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-lg text-sm font-medium hover:from-blue-600 hover:to-purple-700 transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl sm:min-w-48"
           onClick={() => onOpenChat(appointment)}
@@ -46,6 +26,12 @@ const AppointmentActions = ({ appointment, unreadCount, onPay, onCancel, onOpenC
           <ChatIcon />
           Chat
           <UnreadBadge count={unreadCount} />
+        </button>
+        <button
+          className="text-sm text-stone-400 text-center sm:min-w-48 py-2 border rounded hover:bg-red-600 hover:text-white transition-all duration-300"
+          onClick={() => onCancel(appointment._id)}
+        >
+          Cancel Appointment
         </button>
       </>
     );

--- a/frontend/src/Components/appointments/AppointmentCard.jsx
+++ b/frontend/src/Components/appointments/AppointmentCard.jsx
@@ -6,7 +6,7 @@ import { slotDateFormat } from '../../utils/dateUtils';
 const FALLBACK_AVATAR =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDIwMCAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSIjRjNGNEY2Ii8+CjxwYXRoIGQ9Ik0xMDAgNzBDMTE2LjU2OSA3MCAxMzAgODMuNDMxIDMwIDEwMEMxMzAgMTE2LjU2OSAxMTYuNTY5IDEzMCAxMDAgMTMwQzgzLjQzMSAxMzAgNzAgMTE2LjU2OSA3MCAxMEM3MCA4My40MzEgODMuNDMxIDcwIDEwMCA3MFoiIGZpbGw9IiNEMzQ1NEY2Ii8+CjxwYXRoIGQ9Ik0xMDAgMTMwQzExNi41NjkgMTMwIDEzMCAxNDMuNDMxIDEzMCAxNjBDMTMwIDE3Ni41NjkgMTE2LjU2OSAxOTAgMTAwIDE5MEM4My40MzEgMTkwIDcwIDE3Ni41NjkgNzAgMTYwQzcwIDE0My40MzEgODMuNDMxIDEzMCAxMDAgMTMwWiIgZmlsbD0iI0QzNDU0RjYiLz4KPC9zdmc+';
 
-const AppointmentCard = ({ appointment, unreadCount, onPay, onCancel, onOpenChat }) => (
+const AppointmentCard = ({ appointment, unreadCount, onCancel, onOpenChat }) => (
   <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden hover:shadow-md transition-shadow duration-200">
     <div className="p-6">
       <div className="flex flex-col lg:flex-row gap-6">
@@ -54,7 +54,6 @@ const AppointmentCard = ({ appointment, unreadCount, onPay, onCancel, onOpenChat
           <AppointmentActions
             appointment={appointment}
             unreadCount={unreadCount}
-            onPay={onPay}
             onCancel={onCancel}
             onOpenChat={onOpenChat}
           />

--- a/frontend/src/Components/appointments/AppointmentList.jsx
+++ b/frontend/src/Components/appointments/AppointmentList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import AppointmentCard from './AppointmentCard.jsx';
 import EmptyAppointments from './EmptyAppointments.jsx';
 
-const AppointmentList = ({ appointments, unreadCounts, onPay, onCancel, onOpenChat }) => {
+const AppointmentList = ({ appointments, unreadCounts, onCancel, onOpenChat }) => {
   if (appointments.length === 0) return <EmptyAppointments />;
   return (
     <div className="space-y-4">
@@ -11,7 +11,6 @@ const AppointmentList = ({ appointments, unreadCounts, onPay, onCancel, onOpenCh
           key={appointment._id}
           appointment={appointment}
           unreadCount={unreadCounts[appointment._id]}
-          onPay={onPay}
           onCancel={onCancel}
           onOpenChat={onOpenChat}
         />

--- a/frontend/src/Components/appointments/MyAppointmentsHeader.jsx
+++ b/frontend/src/Components/appointments/MyAppointmentsHeader.jsx
@@ -3,15 +3,7 @@ import React from 'react';
 const MyAppointmentsHeader = () => (
   <div className="mb-8">
     <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">My Appointments</h1>
-    <div className="mb-6 flex items-center justify-between">
-      <p className="text-gray-600 dark:text-gray-300">Manage and track your scheduled appointments</p>
-      <div className="flex items-center gap-2 bg-blue-50 dark:bg-blue-900/40 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-200 px-4 py-2 rounded-lg shadow-sm">
-        <svg className="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M12 20a8 8 0 100-16 8 8 0 000 16z" />
-        </svg>
-        <span className="text-sm">Chat with doctor will be available only after payment is completed for the appointment.</span>
-      </div>
-    </div>
+    <p className="text-gray-600 dark:text-gray-300 mb-6">Manage and track your scheduled appointments</p>
   </div>
 );
 

--- a/frontend/src/Pages/MyAppointment.jsx
+++ b/frontend/src/Pages/MyAppointment.jsx
@@ -10,7 +10,7 @@ const MyAppointment = () => {
     chatOpen, chatAppointment, chatMessages, chatLoading,
     chatHasMoreOlder, chatLoadingOlder, loadOlderMessages,
     userData, socket,
-    handlePaynow, cancelAppointment, handleOpenChat, closeChat,
+    cancelAppointment, handleOpenChat, closeChat,
   } = useMyAppointments();
 
   return (
@@ -19,7 +19,6 @@ const MyAppointment = () => {
       <AppointmentList
         appointments={appointments}
         unreadCounts={unreadCounts}
-        onPay={handlePaynow}
         onCancel={cancelAppointment}
         onOpenChat={handleOpenChat}
       />

--- a/frontend/src/hooks/useAppointmentBooking.js
+++ b/frontend/src/hooks/useAppointmentBooking.js
@@ -1,8 +1,13 @@
 import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { loadStripe } from '@stripe/stripe-js';
 import { AppContext } from '../context/AppContext';
-import { bookAppointment as bookAppointmentApi } from '../services/appointmentApi';
+import {
+  bookAppointment as bookAppointmentApi,
+  makePayment as makePaymentApi,
+  cancelAppointment as cancelAppointmentApi,
+} from '../services/appointmentApi';
 import { useSlotGeneration } from './useSlotGeneration';
 
 export const useAppointmentBooking = () => {
@@ -19,6 +24,10 @@ export const useAppointmentBooking = () => {
     setDocInfo(doctors.find((doc) => doc._id === docId) || null);
   }, [doctors, docId]);
 
+  // Booking is now a single user gesture: create the appointment, open the
+  // Stripe Checkout session, redirect. No intermediate "Pending Payment"
+  // step on /my-appointments. If anything in the chain fails after the
+  // appointment row is created, we cancel it so the slot frees instantly.
   const bookAppointment = async () => {
     if (!token) {
       toast.warn('Login to book appointment');
@@ -30,21 +39,34 @@ export const useAppointmentBooking = () => {
     }
 
     setIsBooking(true);
+    let createdAppointmentId = null;
     try {
       const date = docSlot[slotIndex][0].dateTime;
       const slotDate = `${date.getDate()}_${date.getMonth() + 1}_${date.getFullYear()}`;
-      const data = await bookAppointmentApi(token, { docId, slotDate, slotTime });
 
-      if (data.success) {
-        toast.success(data.message);
-        getDoctors();
-        navigate('/my-appointments');
-      } else {
-        toast.error(data.message);
+      const bookData = await bookAppointmentApi(token, { docId, slotDate, slotTime });
+      if (!bookData.success) {
+        toast.error(bookData.message);
+        setIsBooking(false);
+        return;
       }
+      createdAppointmentId = bookData.appointmentId;
+      getDoctors();
+
+      const payData = await makePaymentApi(token, { appointmentId: createdAppointmentId });
+      if (!payData.success) {
+        throw new Error(payData.message || 'Could not start payment.');
+      }
+
+      const stripe = await loadStripe(import.meta.env.VITE_STRIPE_KEY_ID);
+      const { error } = await stripe.redirectToCheckout({ sessionId: payData.sessionId });
+      if (error) throw error;
     } catch (error) {
-      toast.error(error.message);
-    } finally {
+      toast.error(error.message || 'Booking failed.');
+      // Best-effort: free the slot if we already created a row.
+      if (createdAppointmentId) {
+        cancelAppointmentApi(token, { appointmentId: createdAppointmentId }).catch(() => {});
+      }
       setIsBooking(false);
     }
   };

--- a/frontend/src/hooks/useMyAppointments.js
+++ b/frontend/src/hooks/useMyAppointments.js
@@ -1,12 +1,10 @@
 import { useContext, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
-import { loadStripe } from '@stripe/stripe-js';
 import { AppContext } from '../context/AppContext';
 import { useSocketContext } from '../context/SocketContext';
 import {
   getMyAppointments as getMyAppointmentsApi,
   cancelAppointment as cancelAppointmentApi,
-  makePayment as makePaymentApi,
 } from '../services/appointmentApi';
 import { getAppointmentChatMessages } from '../services/chatApi';
 import { useAppointmentUnreadCounts } from './useAppointmentUnreadCounts';
@@ -35,20 +33,6 @@ export const useMyAppointments = () => {
       }
     } catch (error) {
       toast.error(error.message);
-    }
-  };
-
-  const handlePaynow = async (appointmentId) => {
-    const stripe = await loadStripe(import.meta.env.VITE_STRIPE_KEY_ID);
-    try {
-      const data = await makePaymentApi(token, { appointmentId });
-      if (data.success) {
-        await stripe.redirectToCheckout({ sessionId: data.sessionId });
-      } else {
-        toast.error(data.message);
-      }
-    } catch {
-      toast.error('Payment initiation failed.');
     }
   };
 
@@ -127,7 +111,6 @@ export const useMyAppointments = () => {
     chatHasMoreOlder, chatLoadingOlder, loadOlderMessages,
     userData,
     socket,
-    handlePaynow,
     cancelAppointment,
     handleOpenChat,
     closeChat,


### PR DESCRIPTION
Booking is now a single user action: click Book Appointment → backend creates the row + soft lock → frontend chains makePayment + Stripe redirect immediately. No more "Pending Payment" intermediate state on /my-appointments. If anything in the chain fails after the row is created, the frontend cancels it best-effort so the slot frees.

Removed:
- Pay Now / Cancel buttons for unpaid appointments (no longer reachable)
- handlePaynow / onPay prop chain through MyAppointment → List → Card → Actions
- "Chat with doctor will be available only after payment" notice on the appointments header (the unpaid state is invisible now)

Backend allAppointments now filters to paid / cancelled / completed only — soft-locked-but-unpaid rows are an in-flight Stripe checkout and don't belong in the user-facing list.