### PR TITLE
Add Download Receipt button (proxied to fileweaver)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,3 +38,7 @@ EMAIL_FROM=ClickAndCare <noreply@chikitsalaya.live>
 
 # Google OAuth client ID (for /api/user/google-login id-token verification).
 GOOGLE_CLIENT_ID=
+
+# fileweaver report-generation microservice
+FILEWEAVER_URL=https://z02o38znac.execute-api.ap-south-1.amazonaws.com
+FILEWEAVER_API_KEY=fwk_...

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -16,6 +16,7 @@ import {
 import Conversation from '../models/Conversation.js';
 import Message from '../models/Message.js';
 import { getPaginatedMessages } from '../utils/chatPagination.js';
+import { submitReport, getReportJob } from '../utils/fileweaverClient.js';
 
 // Generate 6-digit OTP
 const generateOTP = () => {
@@ -581,6 +582,85 @@ const stripeWebhook = async (req, res) => {
   }
 };
 
+// Kick off (or short-circuit) a paid-appointment receipt generation. Returns
+// either a jobId to poll OR a ready-to-download URL if fileweaver's
+// idempotency layer already has the file. Only the appointment owner can
+// generate; can only generate for paid appointments.
+const requestAppointmentReceipt = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { appointmentId } = req.params;
+    const appt = await appointmentModel.findById(appointmentId);
+    if (!appt) {
+      return res.status(404).json({ success: false, message: 'Appointment not found' });
+    }
+    if (appt.userId !== userId) {
+      return res.status(403).json({ success: false, message: 'Not your appointment' });
+    }
+    if (!appt.payment) {
+      return res.status(409).json({ success: false, message: 'Receipt available only after payment' });
+    }
+
+    let data = await submitReport({
+      type: 'APPOINTMENT_RECEIPT',
+      format: 'PDF',
+      payload: { appointmentId: String(appt._id) },
+    });
+
+    // If fileweaver's idempotency layer returned a previously-failed job,
+    // bypass the cache and force a fresh attempt so the user isn't stuck
+    // on a stale error.
+    if (data.status === 'FAILED') {
+      data = await submitReport({
+        type: 'APPOINTMENT_RECEIPT',
+        format: 'PDF',
+        forceRegenerate: true,
+        payload: { appointmentId: String(appt._id) },
+      });
+    }
+
+    if (data.status === 'COMPLETED' && data.downloadUrl) {
+      return res.json({ success: true, ready: true, downloadUrl: data.downloadUrl, jobId: data.jobId });
+    }
+    res.json({ success: true, ready: false, jobId: data.jobId, status: data.status });
+  } catch (error) {
+    console.error('requestAppointmentReceipt error:', error);
+    res.status(error.status || 500).json({ success: false, message: error.message });
+  }
+};
+
+// Polled by the frontend every few seconds while the receipt is generating.
+// Authorizes the owner, then forwards to fileweaver's GET /reports/{id}.
+const getAppointmentReceiptStatus = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { appointmentId } = req.params;
+    const { jobId } = req.query;
+    if (!jobId) {
+      return res.status(400).json({ success: false, message: 'jobId is required' });
+    }
+    const appt = await appointmentModel.findById(appointmentId);
+    if (!appt) {
+      return res.status(404).json({ success: false, message: 'Appointment not found' });
+    }
+    if (appt.userId !== userId) {
+      return res.status(403).json({ success: false, message: 'Not your appointment' });
+    }
+
+    const job = await getReportJob(jobId);
+    if (job.status === 'COMPLETED' && job.downloadUrl) {
+      return res.json({ success: true, ready: true, downloadUrl: job.downloadUrl, status: job.status });
+    }
+    if (job.status === 'FAILED') {
+      return res.json({ success: true, ready: false, status: 'FAILED', error: job.error });
+    }
+    res.json({ success: true, ready: false, status: job.status });
+  } catch (error) {
+    console.error('getAppointmentReceiptStatus error:', error);
+    res.status(error.status || 500).json({ success: false, message: error.message });
+  }
+};
+
 // API to send forgot password OTP
 const forgotPassword = async (req, res) => {
   try {
@@ -842,4 +922,6 @@ export {
   getUnreadCounts,
   resetAllUnreadCounts,
   googleLogin,
+  requestAppointmentReceipt,
+  getAppointmentReceiptStatus,
 };

--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -17,7 +17,9 @@ import {
   getAppointmentChatMessages,
   getUnreadCounts,
   resetAllUnreadCounts,
-  googleLogin
+  googleLogin,
+  requestAppointmentReceipt,
+  getAppointmentReceiptStatus
 } from '../controllers/userController.js'
 import authUser from '../middlewares/authUser.js'
 import upload from '../middlewares/multer.js'
@@ -45,6 +47,10 @@ userRouter.post('/cancel-appointment', authUser, cancelAppointment)
 userRouter.post('/make-payment', authUser, makePayment)
 userRouter.get('/verify-payment', authUser, verifyPayment)
 userRouter.post('/release-lock', authUser, releaseLock)
+
+// Receipts (proxied to fileweaver)
+userRouter.post('/appointments/:appointmentId/receipt', authUser, requestAppointmentReceipt)
+userRouter.get('/appointments/:appointmentId/receipt/status', authUser, getAppointmentReceiptStatus)
 
 // Chat
 userRouter.get('/appointment/:appointmentId/chat-messages', authUser, getAppointmentChatMessages)

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -29,6 +29,9 @@ provider:
     FRONTEND_URL: ${env:FRONTEND_URL}
     ADMIN_URL: ${env:ADMIN_URL}
     GOOGLE_CLIENT_ID: ${env:GOOGLE_CLIENT_ID, ''}
+    # fileweaver microservice (report generation)
+    FILEWEAVER_URL: ${env:FILEWEAVER_URL, ''}
+    FILEWEAVER_API_KEY: ${env:FILEWEAVER_API_KEY, ''}
   httpApi:
     cors:
       allowedOrigins:

--- a/backend/utils/fileweaverClient.js
+++ b/backend/utils/fileweaverClient.js
@@ -1,0 +1,60 @@
+// Thin wrapper around the fileweaver report-generation microservice.
+// Configured via env vars:
+//   FILEWEAVER_URL      — base URL of the API (e.g. https://...execute-api.../  or http://localhost:8080)
+//   FILEWEAVER_API_KEY  — app-scoped key minted from /admin/api-keys
+//
+// We use the global `fetch` (Node 18+ / Lambda Java21 runtime ships it).
+
+const baseUrl = () => (process.env.FILEWEAVER_URL || '').replace(/\/$/, '');
+const apiKey = () => process.env.FILEWEAVER_API_KEY || '';
+
+const ensureConfigured = () => {
+  if (!baseUrl() || !apiKey()) {
+    throw new Error('Fileweaver not configured (set FILEWEAVER_URL and FILEWEAVER_API_KEY)');
+  }
+};
+
+const headers = () => ({
+  'Content-Type': 'application/json',
+  'X-Api-Key': apiKey(),
+});
+
+/**
+ * Submit a report job. Returns whatever fileweaver returns:
+ *   - 202 Accepted: { jobId, status: "QUEUED" }
+ *   - 200 OK + duplicate: true: { jobId, status: "COMPLETED", downloadUrl, ... }
+ */
+export const submitReport = async ({ type, format, payload, forceRegenerate = false }) => {
+  ensureConfigured();
+  const res = await fetch(`${baseUrl()}/reports`, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify({ type, format, forceRegenerate, payload }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = body?.message || `Fileweaver POST /reports failed (${res.status})`;
+    const err = new Error(msg);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+};
+
+/** Poll a job by id. Returns full job object incl. status + (when COMPLETED) downloadUrl. */
+export const getReportJob = async (jobId) => {
+  ensureConfigured();
+  const res = await fetch(`${baseUrl()}/reports/${encodeURIComponent(jobId)}`, {
+    headers: headers(),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = body?.message || `Fileweaver GET /reports/${jobId} failed (${res.status})`;
+    const err = new Error(msg);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+};

--- a/frontend/src/Components/appointments/AppointmentActions.jsx
+++ b/frontend/src/Components/appointments/AppointmentActions.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import ReceiptButton from './ReceiptButton.jsx';
 
 const ChatIcon = () => (
   <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-  </svg>
+    </svg>
 );
 
 const UnreadBadge = ({ count }) => {
@@ -27,6 +28,7 @@ const AppointmentActions = ({ appointment, unreadCount, onCancel, onOpenChat }) 
           Chat
           <UnreadBadge count={unreadCount} />
         </button>
+        <ReceiptButton appointmentId={appointment._id} />
         <button
           className="text-sm text-stone-400 text-center sm:min-w-48 py-2 border rounded hover:bg-red-600 hover:text-white transition-all duration-300"
           onClick={() => onCancel(appointment._id)}
@@ -38,11 +40,25 @@ const AppointmentActions = ({ appointment, unreadCount, onCancel, onOpenChat }) 
   }
 
   if (appointment.isCompleted) {
-    return <button className="sm:min-w-48 py-2 border border-gray-400 rounded text-gray-500">Appointment Completed</button>;
+    return (
+      <>
+        <button className="sm:min-w-48 py-2 border border-gray-400 rounded text-gray-500">
+          Appointment Completed
+        </button>
+        {appointment.payment && <ReceiptButton appointmentId={appointment._id} />}
+      </>
+    );
   }
 
   if (appointment.cancelled) {
-    return <button className="sm:min-w-48 py-2 border border-red-500 rounded text-red-500">Appointment Cancelled</button>;
+    return (
+      <>
+        <button className="sm:min-w-48 py-2 border border-red-500 rounded text-red-500">
+          Appointment Cancelled
+        </button>
+        {appointment.payment && <ReceiptButton appointmentId={appointment._id} />}
+      </>
+    );
   }
 
   return null;

--- a/frontend/src/Components/appointments/ReceiptButton.jsx
+++ b/frontend/src/Components/appointments/ReceiptButton.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useReceiptDownload } from '../../hooks/useReceiptDownload';
+
+const Spinner = () => (
+  <svg className="animate-spin h-4 w-4 mr-2" viewBox="0 0 24 24" fill="none">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+  </svg>
+);
+
+const DownloadIcon = () => (
+  <svg className="h-4 w-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V4" />
+  </svg>
+);
+
+const ReceiptButton = ({ appointmentId }) => {
+  const { state, start, download } = useReceiptDownload(appointmentId);
+
+  const handleClick = () => {
+    if (state === 'ready') return download();
+    return start();
+  };
+
+  let label;
+  let icon = null;
+  let cls =
+    'inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded transition-all duration-200 sm:min-w-48';
+  if (state === 'idle') {
+    label = 'Download Receipt';
+    icon = <DownloadIcon />;
+    cls += ' border border-gray-300 text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700';
+  } else if (state === 'loading') {
+    label = 'Generating…';
+    icon = <Spinner />;
+    cls += ' border border-gray-300 text-gray-500 cursor-wait dark:border-gray-600 dark:text-gray-400';
+  } else if (state === 'ready') {
+    label = 'Download Receipt';
+    icon = <DownloadIcon />;
+    cls += ' border border-green-500 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20';
+  } else {
+    label = 'Retry';
+    icon = <DownloadIcon />;
+    cls += ' border border-red-500 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20';
+  }
+
+  return (
+    <button onClick={handleClick} className={cls} disabled={state === 'loading'}>
+      {icon}
+      {label}
+    </button>
+  );
+};
+
+export default ReceiptButton;

--- a/frontend/src/hooks/useReceiptDownload.js
+++ b/frontend/src/hooks/useReceiptDownload.js
@@ -1,0 +1,91 @@
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { toast } from 'react-toastify';
+import { AppContext } from '../context/AppContext';
+import { requestReceipt, getReceiptStatus } from '../services/appointmentApi';
+
+const POLL_MS = 5000;
+
+/**
+ * Per-appointment receipt download state machine.
+ *
+ *   idle      ← nothing happening yet
+ *   loading   ← we asked the backend, waiting for fileweaver
+ *   ready     ← downloadUrl in hand, click to download
+ *   error     ← failure, retry by clicking again
+ */
+export const useReceiptDownload = (appointmentId) => {
+  const { token } = useContext(AppContext);
+  const [state, setState] = useState('idle');
+  const [downloadUrl, setDownloadUrl] = useState(null);
+  const pollTimer = useRef(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => stopPolling(), [stopPolling]);
+
+  const startPolling = useCallback(
+    (jobId) => {
+      stopPolling();
+      pollTimer.current = setInterval(async () => {
+        try {
+          const data = await getReceiptStatus(token, appointmentId, jobId);
+          if (data.ready && data.downloadUrl) {
+            setDownloadUrl(data.downloadUrl);
+            setState('ready');
+            stopPolling();
+          } else if (data.status === 'FAILED') {
+            setState('error');
+            stopPolling();
+            toast.error('Receipt generation failed. Try again.');
+          }
+        } catch (err) {
+          // Transient errors during polling — keep going up to a couple retries.
+          console.warn('Receipt poll error:', err?.message);
+        }
+      }, POLL_MS);
+    },
+    [appointmentId, token, stopPolling],
+  );
+
+  const start = useCallback(async () => {
+    if (state === 'loading') return;
+    setState('loading');
+    setDownloadUrl(null);
+    try {
+      const data = await requestReceipt(token, appointmentId);
+      if (data.ready && data.downloadUrl) {
+        setDownloadUrl(data.downloadUrl);
+        setState('ready');
+      } else if (data.jobId) {
+        startPolling(data.jobId);
+      } else {
+        setState('error');
+        toast.error(data.message || 'Could not start receipt generation.');
+      }
+    } catch (err) {
+      setState('error');
+      toast.error(err?.response?.data?.message || err.message || 'Failed to request receipt.');
+    }
+  }, [appointmentId, token, state, startPolling]);
+
+  const download = useCallback(() => {
+    if (!downloadUrl) return;
+    // Direct navigation — fileweaver's presigned URL includes
+    // Content-Disposition: attachment, so the browser downloads instead of
+    // rendering inline. This also avoids the cross-origin fetch path that
+    // hit CORS errors against LocalStack S3.
+    const a = document.createElement('a');
+    a.href = downloadUrl;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }, [downloadUrl]);
+
+  return { state, start, download, downloadUrl };
+};

--- a/frontend/src/services/appointmentApi.js
+++ b/frontend/src/services/appointmentApi.js
@@ -39,3 +39,25 @@ export const releaseLock = async (token, { appointmentId }) => {
   const { data } = await axios.post('/api/user/release-lock', { appointmentId }, authHeader(token));
   return data;
 };
+
+// Kick off (or short-circuit) receipt generation for a paid appointment.
+// Backend proxies to fileweaver. Returns either:
+//   { success:true, ready:true,  downloadUrl }   ← already generated
+//   { success:true, ready:false, jobId }         ← in progress, poll status
+export const requestReceipt = async (token, appointmentId) => {
+  const { data } = await axios.post(
+    `/api/user/appointments/${appointmentId}/receipt`,
+    {},
+    authHeader(token),
+  );
+  return data;
+};
+
+// Poll for completion. Returns { ready: bool, status, downloadUrl? }.
+export const getReceiptStatus = async (token, appointmentId, jobId) => {
+  const { data } = await axios.get(
+    `/api/user/appointments/${appointmentId}/receipt/status`,
+    { params: { jobId }, ...authHeader(token) },
+  );
+  return data;
+};


### PR DESCRIPTION
Per-appointment receipt download for paid appointments. Frontend clicks the button, backend proxies to fileweaver's APPOINTMENT_RECEIPT report, polls every 5s, switches the button to a clickable download once fileweaver returns a presigned URL.

Backend
* utils/fileweaverClient.js: thin wrapper around POST /reports and GET /reports/:id with X-Api-Key auth (FILEWEAVER_URL + FILEWEAVER_API_KEY env vars)
* userController: requestAppointmentReceipt + getAppointmentReceiptStatus. Owner-checks the appointment, requires payment===true, retries with forceRegenerate if fileweaver returns a stale FAILED job
* userRoute: POST /appointments/:id/receipt and GET /appointments/:id/receipt/status
* serverless.yml + .env.example: forward FILEWEAVER_URL and FILEWEAVER_API_KEY into Lambda

Frontend
* services/appointmentApi.js: + requestReceipt + getReceiptStatus
* hooks/useReceiptDownload.js: idle -> loading -> ready state machine with 5s polling, anchor-click navigation (Content-Disposition: attachment from S3 forces download)
* Components/appointments/ReceiptButton.jsx: spinner / green / red states, disabled while loading
* AppointmentActions.jsx: surfaces the button next to Chat for active paid appointments AND below the status badge for completed/ cancelled-but-paid ones

Requires fileweaver to expose APPOINTMENT_RECEIPT (deployed in File-Weaver main). Local dev: set FILEWEAVER_URL=http://localhost:8080 and FILEWEAVER_API_KEY=<a local fwk_... key> in backend/.env.