### PR TITLE
Throttle API Gateway: 25 req/sec sustained, 50 req/sec burst

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -58,6 +58,18 @@ functions:
     events:
       - httpApi: '*'
 
+# API Gateway HTTP API stage-level throttling. Serverless auto-creates the
+# HttpApiStage; we extend it (resources.extensions doesn't conflict with
+# the auto-generated wire-up). Numbers are sized for personal use: 429
+# kicks in around 25 req/sec sustained with up to 50 req/sec bursts.
+resources:
+  extensions:
+    HttpApiStage:
+      Properties:
+        DefaultRouteSettings:
+          ThrottlingBurstLimit: 50
+          ThrottlingRateLimit: 25
+
 package:
   individually: false
   excludeDevDependencies: true


### PR DESCRIPTION
Stage-level throttling via resources.extensions (extends the auto- created HttpApiStage instead of redefining it). API Gateway returns 429 to anyone exceeding the cap, capping Lambda spend before a runaway client (or leaked JWT) can rack up the bill. Numbers higher than fileweaver's because ClickAndCare serves frontend + admin + chat traffic.