### PR TITLE
Fix uneditable signup email field

### DIFF
--- a/frontend/src/Components/auth/EmailInput.jsx
+++ b/frontend/src/Components/auth/EmailInput.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-const EmailInput = ({ value, onChange, disabled = false, id = 'email', placeholder = 'Enter your email', className = '' }) => (
+const EmailInput = ({ value, onChange, disabled = false, id = 'email', name = 'email', placeholder = 'Enter your email', className = '' }) => (
   <input
     id={id}
+    name={name}
     type="email"
     placeholder={placeholder}
     value={value}


### PR DESCRIPTION
EmailInput rendered the underlying <input> without a `name` attribute, so RegisterForm's handleChange (which keys off e.target.name) was writing keystrokes to formData[''] instead of formData.email. Field stayed visually empty and looked uneditable. Default `name='email'` on the component, overridable per usage.